### PR TITLE
Set end time correctly

### DIFF
--- a/public/javascripts/create.js
+++ b/public/javascripts/create.js
@@ -198,6 +198,9 @@ $(document).ready(function() {
       endHours = 0;
     }
     
+    endDate.setHours(endHours);
+    endDate.setMinutes(endMinutes);
+    
     var meetLeader = $('#memberLead').val();
     var meetForm = $('#meetingType').val();
     


### PR DESCRIPTION
Re-adds the code that actually sets the end time for meetings. Oops.