### PR TITLE
Pass hardcoded format on meeting POST to make the API happy

### DIFF
--- a/public/javascripts/create.js
+++ b/public/javascripts/create.js
@@ -203,15 +203,14 @@ $(document).ready(function() {
     
     
     var meetLeader = $('#memberLead').val();
-    var meetForm = $('#meetingType').val();
     
     //meeting object
     var locCoords = parseFloat(createCurrentLocCoords[0]) + "," + parseFloat(createCurrentLocCoords[1]);
     var createMeeting = {
         meetingDate: startDate,
         endTime: endDate,
+        format: "Default",
         location: locCoords,
-        format: meetForm,
         leader: meetLeader,
         members: allMembers,
     };


### PR DESCRIPTION
Meeting creation was failing due to no format string being passed. This feeds it one to make it happy.